### PR TITLE
fix: reinitiate injected repo every resolver

### DIFF
--- a/src/repository/repository.locator.ts
+++ b/src/repository/repository.locator.ts
@@ -7,6 +7,8 @@ export class RepositoryLocator {
 
   constructor(private readonly container: ContainerInstance) {}
 
+  private repositories: AbstractRepository[]  = []
+
   getWithContext<T>(repoKey: typeof AbstractRepository | AbstractRepository, context: T): AbstractRepository {
 
     const repositories = Container.getMany<AbstractRepository>(RepositoryToken);
@@ -16,7 +18,14 @@ export class RepositoryLocator {
       const repo = this.container.get<AbstractRepository>(interfaceType.constructor);
 
       if (interfaceType.constructor === repoKey.constructor || repo.constructor === repoKey.constructor) {
-        return repo.withContext(context);
+        const cached = this.repositories.find((cachedRepo) => cachedRepo.constructor === repo.constructor)
+        if (cached) {
+          return cached;
+        }
+
+        const newRepoWithContext = repo.withContext(context)
+        this.repositories.push(newRepoWithContext)
+        return newRepoWithContext
       }
     }
 


### PR DESCRIPTION
## Issue

Injected repo is re-initiated per resolver, causing it unable to handle batching like [this](https://github.com/graphql/dataloader#batching).

## Change

Injected repo is only initiated once per request (shared by multiple resolvers), instead of per resolver.